### PR TITLE
Add parsing/validation of projects.txt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/pierrre/go-projects
 
 go 1.26.0
+
+require github.com/pierrre/assert v0.15.3
+
+require (
+	github.com/pierrre/compare v1.5.0 // indirect
+	github.com/pierrre/go-libs v0.34.2 // indirect
+	github.com/pierrre/pretty v0.25.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/pierrre/assert v0.15.3 h1:S0Pu9gs199+cQgN5jsFvWKeLKLWRtduEF91dJY3FaP8=
+github.com/pierrre/assert v0.15.3/go.mod h1:eQrZqHsOVeBTchnBrXf2SOakbisq31T3r9F78Dbx/ns=
+github.com/pierrre/compare v1.5.0 h1:t+QADhk3WbkMAljPAb07mpYSs5kl+N1iUEJyKntIsWY=
+github.com/pierrre/compare v1.5.0/go.mod h1:ftjRfyE24SAsG3vNwZpcqy5lw9pD+JoMDul0tfyL7TI=
+github.com/pierrre/go-libs v0.34.2 h1:c1YvhtOCMCUKgp8jdkxJqbluSw5QXmfgrfNZohH01E0=
+github.com/pierrre/go-libs v0.34.2/go.mod h1:5Fr5EGlSmOhrPOGfPLz4nwR4ljKoe/gek04XrWmYNNM=
+github.com/pierrre/pretty v0.25.1 h1:yKQlh4QHwcQaLbBf/ljdlSQYzl9FxipXbRFmTS6WqOo=
+github.com/pierrre/pretty v0.25.1/go.mod h1:yNcAnolSTOvSoxK35p/OVcbi9pmPCpRgmzN0wmoQU+A=

--- a/projects.go
+++ b/projects.go
@@ -1,2 +1,57 @@
 // Package projects allows managing Go projects.
 package projects
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+//go:embed projects.txt
+var file []byte
+
+// Project is a project name.
+type Project string
+
+// List is the list of projects parsed from projects.txt.
+var List = MustParse(file)
+
+// Parse parses and validates project names from data.
+//
+// Names are read one per line. Blank lines are ignored and surrounding whitespace is trimmed.
+//
+// It returns an error if the result is empty, if a name is duplicated, or if the names are not sorted in ascending order.
+func Parse(data []byte) ([]Project, error) {
+	lines := strings.Split(string(data), "\n")
+	var ps []Project
+	for i, line := range lines {
+		name := strings.TrimSpace(line)
+		if name == "" {
+			continue
+		}
+		if len(ps) > 0 {
+			prev := string(ps[len(ps)-1])
+			if name == prev {
+				return nil, fmt.Errorf("duplicate project %q at line %d", name, i+1)
+			}
+			if name < prev {
+				return nil, fmt.Errorf("project %q at line %d is not sorted (previous %q)", name, i+1, prev)
+			}
+		}
+		ps = append(ps, Project(name))
+	}
+	if len(ps) == 0 {
+		return nil, errors.New("no projects")
+	}
+	return ps, nil
+}
+
+// MustParse calls [Parse] and panics if there is an error.
+func MustParse(data []byte) []Project {
+	ps, err := Parse(data)
+	if err != nil {
+		panic(err)
+	}
+	return ps
+}

--- a/projects_test.go
+++ b/projects_test.go
@@ -1,0 +1,119 @@
+package projects
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/pierrre/assert"
+)
+
+func ExampleList() {
+	for _, p := range List {
+		fmt.Println(p)
+	}
+	// Output:
+	// assert
+	// cellauto
+	// compare
+	// di
+	// errors
+	// file-duplicate
+	// file-random
+	// geohash
+	// githubhook
+	// go-cache-prog
+	// go-libs
+	// go-stuff
+	// image-viewer
+	// langton
+	// mandelbrot
+	// pretty
+	// unlimited-channel
+	// vld
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		want    []Project
+		wantErr string
+	}{
+		{
+			name: "single",
+			data: "a",
+			want: []Project{"a"},
+		},
+		{
+			name: "multiple",
+			data: "a\nb\nc\n",
+			want: []Project{"a", "b", "c"},
+		},
+		{
+			name: "blank lines ignored",
+			data: "\na\n\nb\n\n",
+			want: []Project{"a", "b"},
+		},
+		{
+			name: "whitespace trimmed",
+			data: " a \n\tb\t\n",
+			want: []Project{"a", "b"},
+		},
+		{
+			name: "trailing newline",
+			data: "a\nb",
+			want: []Project{"a", "b"},
+		},
+		{
+			name:    "empty",
+			data:    "",
+			wantErr: "no projects",
+		},
+		{
+			name:    "only blank lines",
+			data:    "\n\n",
+			wantErr: "no projects",
+		},
+		{
+			name:    "duplicate",
+			data:    "a\na\n",
+			wantErr: `duplicate project "a" at line 2`,
+		},
+		{
+			name:    "not sorted",
+			data:    "b\na\n",
+			wantErr: `project "a" at line 2 is not sorted (previous "b")`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse([]byte(tt.data))
+			if tt.wantErr != "" {
+				assert.ErrorEqual(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.SliceEqual(t, got, tt.want)
+		})
+	}
+}
+
+func TestMustParse(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		ps := MustParse([]byte("a\nb\n"))
+		assert.SliceEqual(t, ps, []Project{"a", "b"})
+	})
+	t.Run("panic", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustParse([]byte("a\na\n"))
+		})
+	})
+}
+
+func TestList(t *testing.T) {
+	assert.SliceNotEmpty(t, List)
+	assert.True(t, slices.IsSorted(List))
+	uniq := slices.Compact(slices.Clone(List))
+	assert.SliceLen(t, uniq, len(List))
+}


### PR DESCRIPTION
`projects.go` was a 2-line stub and `projects.txt` was only consumed via shell (`cat | xargs`).

This adds a typed Go API so the project list is consumable programmatically:

- `//go:embed projects.txt` embeds the file.
- `type Project string` is a typed project name.
- `Parse(data []byte) ([]Project, error)` parses line-by-line (trims whitespace, skips blank lines) and validates: non-empty result, no duplicates, sorted ascending.
- `MustParse` panics on error.
- `var List = MustParse(file)` exposes the ready-to-use validated list.

Tests cover the happy paths, each validation error (with line numbers), `MustParse` panic, and an `ExampleList` that locks the embedded file content.