### PR TITLE
Expand README.md with purpose, projects.txt format, and Makefile usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Go projects
+
+This repository manages a collection of Go projects hosted under `github.com/pierrre/`.
+
+It provides a `projects.txt` file listing the project names and a Makefile that fans out commands across all sibling repositories.
+
+## projects.txt
+
+The `projects.txt` file lists the Go project names managed by this repository.
+
+Each line is a project name, one per line.
+The names correspond to repository names under `github.com/pierrre/`.
+They are sorted in ascending order and must not contain duplicates.
+
+## Makefile
+
+The Makefile defines targets that operate across every project listed in `projects.txt`.
+Each target iterates over the project names and runs a command in the corresponding sibling directory (`../<project>`).
+
+The main targets are:
+
+- `all-git-clone`: clones every project repository into the parent directory.
+- `all-copy-common`: copies shared files (`Makefile-common.mk`, `LICENSE`, `CODEOWNERS`, `.gitignore`, `.github`, `.golangci.yml`) into every project.
+- `all-all`: runs `make all` (build, test, lint) in every project.
+- `all-build`: runs `make build` in every project.
+- `all-test`: runs `make test` in every project.
+- `all-lint`: runs `make lint` in every project.
+- `all-clean`: runs `make clean` in every project.
+- `all-run COMMAND=<cmd>`: runs an arbitrary command in every project directory (defaults to `ls`).
+
+The `GIT_REPOSITORY_PATTERN` variable controls the clone URL: SSH by default, HTTPS when `CODESPACES=true`.


### PR DESCRIPTION
The README was a single title line.

This expands it to describe:
- The purpose of the repository (managing a collection of Go projects under github.com/pierrre/)
- The projects.txt format (one project name per line, sorted, no duplicates)
- The key Makefile targets (all-git-clone, all-copy-common, all-all, all-build, all-test, all-lint, all-clean, all-run) and the GIT_REPOSITORY_PATTERN variable

Note: the task description mentioned documenting a Go API (Parse, MustParse, List, Project) in projects.go, but that API only exists on the unmerged feature/projects-parsing branch, not on main. On main, projects.go is a minimal package declaration with no exported symbols, so there is nothing to document. This PR matches the original P1 idea from ideas.md: describe purpose, the projects.txt format, and Makefile usage.